### PR TITLE
docs: add philosophy references to README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,20 @@ alwaysApply: true
 
 # ECS Game Engine Development Guidelines
 
+## Core Philosophy
+
+**All development must adhere to the principles outlined in [PHILOSOPHY.md](PHILOSOPHY.md).**
+
+Key principles that guide all code contributions:
+- **Entities are IDs, Components are pure data** - No logic in components
+- **All game logic belongs in systems** - System-driven behavior is non-negotiable
+- **Optimize for cache locality and performance** - Data-driven design principles
+- **Single Responsibility Principle** - Each system, component, and entity has one purpose
+- **Developer ergonomics** - APIs must be simple, focused, and avoid boilerplate
+- **Robust tooling culture** - Debugging and profiling are first-class citizens
+
+**Before making any changes, review the complete philosophy document to ensure alignment with project principles.**
+
 ## Runtime & Tools
 
 **Use Bun for all operations:**

--- a/PHILOSOPHY.md
+++ b/PHILOSOPHY.md
@@ -1,0 +1,71 @@
+## **ECS Engine Constitution & Principles**
+
+### **1. Purity of Purpose**
+
+- **Entities are IDs, and nothing more.**  
+  No logic, no state beyond a unique identifier.
+- **Components are pure data.**  
+  Components must never contain behaviour. If in doubt, split logic from data.
+
+### **2. System-Driven Behaviour**
+
+- **All game logic belongs in systems.**  
+  Only systems update, process, or apply behaviour. This is non-negotiable.
+- **Behaviours are composable.**  
+  Adding features should mean adding new systems or components, not changing what’s already written.
+
+### **3. Data-Driven Design**
+
+- **Optimise for cache locality and performance.**  
+  Store similar components together. Prioritise memory layout and data access patterns that scale with thousands of entities.
+- **Profile often, optimise performance bottlenecks, and avoid premature optimisation.**
+
+### **4. Modularity & Extensibility**
+
+- **Each system, component, and entity must adhere to the Single Responsibility Principle.**
+- **Open for extension, closed for modification.**  
+  New features are added by composing new entities from existing components—not rewriting old systems.
+
+### **5. Developer Ergonomics**
+
+- **APIs must be simple, focused, and avoid boilerplate.**
+- **Favour clarity over cleverness.**  
+  Code should be self-explanatory, not require expert-level ECS knowledge to extend or understand.
+- **Readability is mandatory; comments explain ‘why’, not ‘what’.**
+
+### **6. Robust Tooling Culture**
+
+- **Debugging, profiling, and tracing are first-class citizens.**
+- **If you break a profiling build or debugger, you must fix it.**  
+  Never leave tooling broken or incomplete.
+
+### **7. Scalability and Parallelism**
+
+- **Architect for parallel execution.**  
+  Any system that can run in parallel, must be safe to do so.
+- **Race conditions and data hazards are unacceptable.**  
+  Document and defend all multithreaded assumptions.
+
+### **8. Testing and Continuous Integration**
+
+- **Thoroughly test new systems and components, especially at their boundaries.**
+- **No code reaches `main` without passing all established checks, tests, and linters.**
+
+### **9. Documentation & Knowledge Sharing**
+
+- **Document every component, system, and architectural decision.**  
+  Contributors must be able to understand and critique any part of the codebase with written guidance.
+- **Major design choices must be recorded in the repo via decision log or ADRs (Architectural Decision Records).**
+
+### **10. Community & Respect**
+
+- **Critique code, never people.**  
+  Our mutual goal is building something great, not being ‘right’.
+- **Encourage discussions, RFCs, and technical debate.**  
+  All major engine evolutions must be discussed publicly before being merged.
+
+---
+
+### **Summary Statement**
+
+_"This engine is built on the principle that simplicity, composability, and data-oriented design create robust, scalable, high-performance games. We treat tooling, documentation, and developer experience as core features. All contributors are custodians of this philosophy—accountable to its vision and to each other."_

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@
 - Type-safe network protocol
 - Built-in authentication and session management
 
+## 📜 Philosophy
+
+This engine is built on a foundation of core principles that prioritize **purity, performance, and developer experience**. Our approach emphasizes:
+
+- **Data-driven design** with pure components and system-driven behavior
+- **Performance optimization** through cache-friendly memory layouts and archetype-based storage
+- **Developer ergonomics** with simple, focused APIs that avoid boilerplate
+- **Scalability and parallelism** designed for high-performance game development
+
+For the complete philosophy and design principles that guide this project, see [PHILOSOPHY.md](PHILOSOPHY.md).
+
 ## 🚀 Quick Start
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- Add Philosophy section to README.md highlighting core principles
- Add Core Philosophy section to CLAUDE.md development guidelines  
- Reference PHILOSOPHY.md document for complete design principles
- Ensure all contributors understand ECS philosophy before making changes

## Test plan
- [x] Documentation updates only - no code changes
- [x] All tests passing
- [x] TypeScript compilation successful
- [x] Philosophy document properly referenced in both files