### PR TITLE
fix(ci): correct archive path in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,7 +67,7 @@ jobs:
       - name: 📦 Create distribution archive
         run: |
           mkdir -p release-assets
-          tar -czf release-assets/ecs-ts-${{ needs.release-please.outputs.tag_name }}.tar.gz \
+          tar -czf release-assets/${{ needs.release-please.outputs.tag_name }}.tar.gz \
             dist/ \
             package.json \
             README.md \
@@ -81,8 +81,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release-please.outputs.upload_url }}
-          asset_path: ./release-assets/ecs-ts-${{ needs.release-please.outputs.tag_name }}.tar.gz
-          asset_name: ecs-ts-${{ needs.release-please.outputs.tag_name }}.tar.gz
+          asset_path: ./release-assets/${{ needs.release-please.outputs.tag_name }}.tar.gz
+          asset_name: ${{ needs.release-please.outputs.tag_name }}.tar.gz
           asset_content_type: application/gzip
 
       # Future: NPM publishing when ready


### PR DESCRIPTION
## Summary
- Fixed duplicate 'ecs-ts-' prefix in tar archive filename causing release workflow failures
- The release-please action already outputs tag names with repository prefix
- Previous code created invalid nested directory paths that broke the tar command

## Problem
GitHub Actions run #17884566941 failed with:
```
tar (child): release-assets/ecs-ts-ecs-ts/v0.6.6.tar.gz: Cannot open: No such file or directory
```

## Solution
Removed hardcoded 'ecs-ts-' prefix and use tag name directly from release-please output.

## Test Plan
- [x] All tests pass locally
- [x] TypeScript compilation successful
- [ ] Verify next release workflow completes successfully