### PR TITLE
fix(ci): handle forward slashes in release archive paths

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,7 +67,9 @@ jobs:
       - name: 📦 Create distribution archive
         run: |
           mkdir -p release-assets
-          tar -czf release-assets/${{ needs.release-please.outputs.tag_name }}.tar.gz \
+          TAG_NAME="${{ needs.release-please.outputs.tag_name }}"
+          FILENAME="${TAG_NAME//\//-}"  # Replace / with -
+          tar -czf release-assets/${FILENAME}.tar.gz \
             dist/ \
             package.json \
             README.md \
@@ -76,14 +78,14 @@ jobs:
             examples/
 
       - name: 📤 Upload Release Assets
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.release-please.outputs.upload_url }}
-          asset_path: ./release-assets/${{ needs.release-please.outputs.tag_name }}.tar.gz
-          asset_name: ${{ needs.release-please.outputs.tag_name }}.tar.gz
-          asset_content_type: application/gzip
+        run: |
+          TAG_NAME="${{ needs.release-please.outputs.tag_name }}"
+          FILENAME="${TAG_NAME//\//-}"  # Replace / with -
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/gzip" \
+            --data-binary @"./release-assets/${FILENAME}.tar.gz" \
+            "${{ needs.release-please.outputs.upload_url }}?name=${FILENAME}.tar.gz&label=${FILENAME}.tar.gz"
 
       # Future: NPM publishing when ready
       # - name: 📦 Publish to NPM


### PR DESCRIPTION
## Summary
- Fixed forward slash handling in release-please tag names causing tar command failures
- Tag names like 'ecs-ts/v0.6.7' now become 'ecs-ts-v0.6.7.tar.gz' 
- Switched to curl for asset upload to maintain filename consistency

## Problem
Previous fix in #17 only removed duplicate prefix but didn't handle forward slashes.
GitHub Actions continue failing with:
```
tar (child): release-assets/ecs-ts/v0.6.7.tar.gz: Cannot open: No such file or directory
```

## Solution
- Replace forward slashes with hyphens in both archive creation and upload steps
- Use shell parameter expansion `${TAG_NAME//\//-}` to sanitize filenames
- Switch from GitHub Actions upload action to curl for consistent behavior

## Test Plan
- [x] All tests pass locally  
- [x] TypeScript compilation successful
- [ ] Verify next release workflow completes successfully

## Related Issues
- Resolves GitHub Actions run #17884566941
- Resolves GitHub Actions run #17884615964