### PR TITLE
fix(ci): add publishConfig for public npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- Add `publishConfig.access: "public"` to package.json
- Fixes 402 Payment Required error when publishing scoped package to npm

## Problem
Scoped packages (starting with `@`) require a paid npm account unless explicitly published as public. The automated publishing was failing with:

```
npm error code E402
npm error 402 Payment Required - PUT https://registry.npmjs.org/@danjdewhurst%2fecs-ts - You must sign up for private packages
```

## Solution
The `publishConfig` section ensures the package is always published as public, both for manual and automated publishes.

## Test Plan
- [x] Package.json format validated
- [x] All tests pass (132/132)
- [x] TypeScript compilation clean

This will fix the automated GitHub Actions publishing for future releases.