### PR TITLE
fix(ci): correct NPM publish condition for tag format

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,7 +88,7 @@ jobs:
             "${{ needs.release-please.outputs.upload_url }}?name=${FILENAME}.tar.gz&label=${FILENAME}.tar.gz"
 
       - name: 📦 Publish to NPM
-        if: ${{ !contains(needs.release-please.outputs.tag_name, '-') }}
+        if: ${{ !contains(needs.release-please.outputs.tag_name, '-alpha') && !contains(needs.release-please.outputs.tag_name, '-beta') && !contains(needs.release-please.outputs.tag_name, '-rc') }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
           npm publish --access public


### PR DESCRIPTION
## Summary
- Fixed NPM publish condition that was incorrectly blocking releases with forward slashes in tag names
- Updated condition to specifically check for pre-release patterns (-alpha, -beta, -rc) instead of any dash

## Problem
The Release Please GitHub Action was skipping NPM publishing because the condition `!contains(tag_name, '-')` was too broad. With tags like `ecs-ts/v0.7.2`, the condition incorrectly blocked publishing even though these are stable releases.

## Solution
Updated the condition to specifically check for pre-release patterns:
```yaml
if: ${{ !contains(needs.release-please.outputs.tag_name, '-alpha') && !contains(needs.release-please.outputs.tag_name, '-beta') && !contains(needs.release-please.outputs.tag_name, '-rc') }}
```

## Test plan
- [x] Commit follows conventional commit format
- [x] All tests pass
- [x] TypeScript compilation successful
- [ ] Verify NPM publishing works in next release