### PR TITLE
fix(ci): add NPM provenance and OIDC auth to bypass 2FA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  id-token: write
 
 jobs:
   release-please:
@@ -91,6 +92,6 @@ jobs:
         if: ${{ !contains(needs.release-please.outputs.tag_name, '-alpha') && !contains(needs.release-please.outputs.tag_name, '-beta') && !contains(needs.release-please.outputs.tag_name, '-rc') }}
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-          npm publish --access public
+          npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Adds NPM provenance support and GitHub OIDC authentication to resolve 2FA publishing failures in automated releases.

## Problem
Following the fix in PR #34, NPM publishing now runs but fails with 2FA requirements:
```
npm error code EOTP
npm error This operation requires a one-time password from your authenticator.
```

GitHub Actions cannot provide interactive OTP codes, blocking automated releases.

## Solution
**1. Added GitHub OIDC Authentication:**
```yaml
permissions:
  id-token: write  # Enables GitHub OIDC token generation
```

**2. Added NPM Provenance:**
```yaml
npm publish --access public --provenance
```

This provides:
- Supply chain security through cryptographic attestation
- Alternative authentication via GitHub OIDC instead of traditional 2FA
- Verification that packages were built in GitHub Actions

## Additional Action Required
**Update NPM Token**: The `NPM_TOKEN` GitHub secret should be replaced with an NPM **automation token**:

1. Visit https://www.npmjs.com/settings/tokens
2. Generate New Token → Select **"Automation"** type
3. Replace `NPM_TOKEN` secret in repository settings

Automation tokens bypass 2FA requirements for CI/CD while maintaining security.

## Test Plan
- [x] Follows conventional commit format  
- [x] All tests pass
- [x] TypeScript compilation successful
- [x] Adds OIDC permission for GitHub identity tokens
- [x] Uses provenance for supply chain security
- [ ] Verify NPM publishing works after automation token update

## References
- [NPM Provenance Documentation](https://docs.npmjs.com/generating-provenance-statements)
- [GitHub OIDC Documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)